### PR TITLE
Added vercel-deployed frontend address to origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,7 +43,8 @@ supabase: Client = create_client(
 # only allow React dev server to send API requests to server
 origins = [
     "http://localhost:5173",
-    "http://127.0.0.1:5173"
+    "http://127.0.0.1:5173",
+    "https://www.gamesnotfound.com"
 ]
 
 app.add_middleware(


### PR DESCRIPTION
CORS origins on server only allow requests from localhost.  I need to add GamesNotFound.com to the list of allowed origins.